### PR TITLE
Export type declarations for "moduleResolution": "bundler"

### DIFF
--- a/packages/solid-resizable-panels/package.json
+++ b/packages/solid-resizable-panels/package.json
@@ -12,7 +12,8 @@
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",
       "node": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./styles.css": "./dist/styles.css"
   },


### PR DESCRIPTION
When the `moduleResolution` compiler option is set to `bundler` in `tsconfig.json`, the `solid-resizable-panels`'s type declarations can't be found. The following error gets returned:

`Could not find a declaration file for module 'solid-resizable-panels'. '<PROJECT_PATH>/node_modules/solid-resizable-panels/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '<PROJECT_PATH>/node_modules/solid-resizable-panels/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'solid-resizable-panels' library may need to update its package.json or typings.`

This pull requests adds the required `types` export to make it work correctly.